### PR TITLE
possibility to specify source range

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -21,7 +21,7 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   direction                   = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 0)}"
   access                      = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 1)}"
   protocol                    = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 2)}"
-  source_port_ranges          = "${split(",", replace(  "${lookup(var.predefined_rules[count.index], "source_port_range", "*" )}"  ,  "*" , "0-65535" ) )}"
+  source_port_range           = "${lookup(var.predefined_rules[count.index], "source_port_range", "*" )}"
   destination_port_range      = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 4)}"
   description                 = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 5)}"
   source_address_prefix       = "${lookup(var.predefined_rules[count.index], "source_address_prefix", "*")}"

--- a/main.tf
+++ b/main.tf
@@ -24,7 +24,7 @@ resource "azurerm_network_security_rule" "predefined_rules" {
   source_port_ranges          = "${split(",", replace(  "${lookup(var.predefined_rules[count.index], "source_port_range", "*" )}"  ,  "*" , "0-65535" ) )}"
   destination_port_range      = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 4)}"
   description                 = "${element(var.rules["${lookup(var.predefined_rules[count.index], "name")}"], 5)}"
-  source_address_prefix       = "${join(",", var.source_address_prefix)}"
+  source_address_prefix       = "${lookup(var.predefined_rules[count.index], "source_address_prefix", "*")}"
   destination_address_prefix  = "${join(",", var.destination_address_prefix)}"
   resource_group_name         = "${azurerm_resource_group.nsg.name}"
   network_security_group_name = "${azurerm_network_security_group.nsg.name}"


### PR DESCRIPTION
Possibly more often than not, you will want to specify source address ranges (or virtual subnets) for predefined rules. I think we're fine with taking the global "destination_address_prefix" for single rules. This makes something work that is already specified in README.md:
```
predefined_rules           = [
      {
        name                   = "SSH"
        priority               = "500"
        source_address_prefix  = ["10.0.3.0/24"]
      },
]
```